### PR TITLE
Fix i18n init on client

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,6 @@ import ClientRoot from '@/components/ClientRoot';
 import { Toaster } from '@/components/ui/toaster';
 import { Analytics } from '@/components/analytics';
 import '@/styles/globals.css';
-import '@/i18n';
 
 const inter = Inter({
   subsets: ['latin'],

--- a/src/components/ClientRoot.tsx
+++ b/src/components/ClientRoot.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { Providers } from "@/components/providers";
+import '@/i18n';
 
 export default function ClientRoot({ children }: { children: React.ReactNode }) {
   return <Providers>{children}</Providers>;


### PR DESCRIPTION
## Summary
- avoid initializing i18n on server
- load i18n in `ClientRoot` instead of `layout`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686c3b9597cc832d98d568f84b192dfb