### PR TITLE
feat: add MapLibre map component

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cp env.example .env.local
 npm run dev
 ```
 
-Visit [http://localhost:3000](http://localhost:3000) to see your app!
+Visit [http://localhost:3000](http://localhost:3000) to see your app! The map is available at [http://localhost:3000/map](http://localhost:3000/map).
 
 ## 📚 Documentation
 
@@ -102,6 +102,8 @@ Create a `.env.local` file with the following variables:
 ```env
 # Database
 DATABASE_URL="your-supabase-database-url"
+NEXT_PUBLIC_SUPABASE_URL="https://your-project-ref.supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="your-supabase-anon-key"
 
 # Authentication
 NEXTAUTH_URL="http://localhost:3000"
@@ -112,6 +114,7 @@ RESEND_API_KEY="your-resend-api-key"
 
 # Maps
 GOOGLE_MAPS_API_KEY="your-google-maps-api-key"
+NEXT_PUBLIC_MAPTILER_KEY="your-maptiler-key"
 
 # Optional
 NEXT_PUBLIC_GA_ID="your-google-analytics-id"

--- a/env.example
+++ b/env.example
@@ -26,6 +26,7 @@ AWS_S3_BUCKET="anemi-meets-uploads"
 # Maps & Location Services
 GOOGLE_MAPS_API_KEY="your-google-maps-api-key"
 MAPBOX_ACCESS_TOKEN="your-mapbox-access-token"
+NEXT_PUBLIC_MAPTILER_KEY="your-maptiler-key"
 
 # Redis (for caching and sessions)
 REDIS_URL="redis://localhost:6379"

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "leaflet": "^1.9.4",
     "lucide-react": "^0.468.0",
     "mapbox-gl": "^3.1.2",
+    "maplibre-gl": "^3.5.2",
     "next": "^14.2.30",
     "next-pwa": "^5.6.0",
     "next-rate-limit": "^0.0.3",

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -1,0 +1,9 @@
+import AnemiMap from '@/components/AnemiMap';
+
+export default function MapPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-amber-50 via-cream-50 to-orange-50 p-4">
+      <AnemiMap />
+    </div>
+  );
+}

--- a/src/components/AnemiMap.tsx
+++ b/src/components/AnemiMap.tsx
@@ -1,0 +1,351 @@
+"use client";
+import { useEffect, useMemo, useRef, useState } from "react";
+import maplibregl, { Map, Popup } from "maplibre-gl";
+import "maplibre-gl/dist/maplibre-gl.css";
+import { createClient } from "@supabase/supabase-js";
+import { ANEMI } from "@/theme/anemi";
+
+type Cafe = {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+  city: string | null;
+  verified: boolean | null;
+  badges: string[] | null;
+  photo_url: string | null;
+  owner_quote: string | null;
+};
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);
+
+// Minimal brand container styles
+const containerStyle: React.CSSProperties = {
+  height: "72vh",
+  width: "100%",
+  borderRadius: ANEMI.radius as unknown as number,
+  boxShadow: ANEMI.shadow as unknown as string,
+  overflow: "hidden",
+  background: ANEMI.cream,
+};
+
+export default function AnemiMap() {
+  const mapRef = useRef<Map | null>(null);
+  const nodeRef = useRef<HTMLDivElement | null>(null);
+  const [cafes, setCafes] = useState<Cafe[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [city, setCity] = useState<string>("All");
+  const [onlyVerified, setOnlyVerified] = useState<boolean>(false);
+
+  const styleUrl = useMemo(() => {
+    // MapTiler Dataviz Light (clean, neutral). Create a free key and set NEXT_PUBLIC_MAPTILER_KEY
+    return `https://api.maptiler.com/maps/dataviz/style.json?key=${process.env.NEXT_PUBLIC_MAPTILER_KEY}`;
+  }, []);
+
+  const centerNL: [number, number] = useMemo(() => [5.2913, 52.1326], []);
+
+  useEffect(() => {
+    supabase
+      .from("cafes")
+      .select("id,name,lat,lng,city,verified,badges,photo_url,owner_quote")
+      .then(({ data, error }) => {
+        if (!error && data) setCafes(data as Cafe[]);
+        setLoading(false);
+      });
+  }, []);
+
+  // Build filtered GeoJSON
+  const geo = useMemo(() => {
+    const filtered = cafes.filter(
+      (c) => (city === "All" || c.city === city) && (!onlyVerified || !!c.verified)
+    );
+    return {
+      type: "FeatureCollection" as const,
+      features: filtered.map((c) => ({
+        type: "Feature" as const,
+        properties: {
+          id: c.id,
+          name: c.name,
+          city: c.city ?? "",
+          verified: !!c.verified,
+          badges: c.badges ?? [],
+          photo_url: c.photo_url ?? "",
+          owner_quote: c.owner_quote ?? "",
+        },
+        geometry: { type: "Point" as const, coordinates: [c.lng, c.lat] },
+      })),
+    };
+  }, [cafes, city, onlyVerified]);
+
+  // Unique city list for chip filter
+  const cities = useMemo(() => {
+    const set = new Set<string>(["All"]);
+    cafes.forEach((c) => c.city && set.add(c.city));
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
+  }, [cafes]);
+
+    // Init / update map
+    useEffect(() => {
+      if (!nodeRef.current || mapRef.current) return;
+    const map = new maplibregl.Map({
+      container: nodeRef.current,
+      style: styleUrl,
+      center: centerNL,
+      zoom: 6.8,
+      attributionControl: false,
+      pitchWithRotate: false,
+      dragRotate: false,
+    });
+    mapRef.current = map;
+
+    // Minimal brand UI
+    map.addControl(new maplibregl.NavigationControl({ showCompass: false }), "bottom-right");
+
+    map.on("load", () => {
+      map.addSource("cafes", {
+        type: "geojson",
+        data: geo,
+        cluster: true,
+        clusterRadius: 50,
+        clusterMaxZoom: 13,
+      });
+
+      // Cluster circles
+      map.addLayer({
+        id: "clusters",
+        type: "circle",
+        source: "cafes",
+        filter: ["has", "point_count"],
+        paint: {
+          "circle-color": [
+            "step",
+            ["get", "point_count"],
+            ANEMI.tealSoft,
+            25,
+            "#A9DBD6",
+            75,
+            ANEMI.teal,
+          ],
+          "circle-radius": [
+            "step",
+            ["get", "point_count"],
+            14,
+            25,
+            18,
+            75,
+            24,
+          ],
+          "circle-stroke-width": 2,
+          "circle-stroke-color": "#ffffff",
+        },
+      });
+
+      // Cluster counts
+      map.addLayer({
+        id: "cluster-count",
+        type: "symbol",
+        source: "cafes",
+        filter: ["has", "point_count"],
+        layout: {
+          "text-field": ["get", "point_count_abbreviated"],
+          "text-font": ["Noto Sans Regular"],
+          "text-size": 12,
+        },
+        paint: { "text-color": ANEMI.ink },
+      });
+
+      // Unclustered points (verified vs not)
+      map.addLayer({
+        id: "unclustered-point",
+        type: "circle",
+        source: "cafes",
+        filter: ["!", ["has", "point_count"]],
+        paint: {
+          "circle-radius": 7,
+          "circle-color": [
+            "case",
+            ["get", "verified"],
+            ANEMI.verified, // green for verified
+            ANEMI.teal, // teal for normal
+          ],
+          "circle-stroke-width": 2,
+          "circle-stroke-color": "#ffffff",
+        },
+      });
+
+      // Popups
+      const popup = new Popup({ closeButton: true, closeOnClick: true, maxWidth: "320px" });
+
+      map.on("click", "clusters", (e) => {
+        const features = map.queryRenderedFeatures(e.point, { layers: ["clusters"] });
+        const clusterId = features[0].properties?.cluster_id;
+        const source: any = map.getSource("cafes");
+        source.getClusterExpansionZoom(clusterId, (err: any, zoom: number) => {
+          if (err) return;
+          map.easeTo({ center: (features[0].geometry as any).coordinates, zoom });
+        });
+      });
+
+      map.on("click", "unclustered-point", (e) => {
+        const f = e.features?.[0];
+        if (!f) return;
+        const p = f.properties as any;
+        const coords = (f.geometry as any).coordinates.slice();
+
+        const badges = JSON.parse(p.badges || "[]") as string[];
+        const badgeHtml = badges
+          .map(
+            (b: string) =>
+              `<span style="font-size:11px;padding:2px 8px;border:1px solid #E6ECF2;border-radius:999px;margin-right:6px;">${b}</span>`
+          )
+          .join("");
+
+        const check = p.verified === true || p.verified === "true";
+        const photo = p.photo_url
+          ? `<img src="${p.photo_url}" style="width:100%;border-radius:12px;margin-top:8px;">`
+          : "";
+
+        const card = `
+          <div style="font-family: system-ui,-apple-system,Segoe UI,Roboto,Inter; color:${ANEMI.ink};">
+            <div style="background:${ANEMI.sand};border-radius:14px;padding:12px;box-shadow:${ANEMI.shadow}">
+              <div style="display:flex;align-items:center;gap:8px;">
+                <div style="width:10px;height:10px;border-radius:50%;background:${check ? ANEMI.verified : ANEMI.teal};border:2px solid #fff;box-shadow:0 1px 3px rgba(0,0,0,.2)"></div>
+                <div style="font-weight:600">${p.name}${check ? " ✔︎" : ""}</div>
+              </div>
+              <div style="font-size:12px;color:${ANEMI.muted};margin-top:4px;">${p.city || ""}</div>
+              ${photo}
+              ${p.owner_quote ? `<div style="font-size:12px;fontStyle:italic;margin-top:8px;">“${p.owner_quote}”</div>` : ""}
+              ${badges.length ? `<div style="margin-top:10px;display:flex;flex-wrap:wrap;gap:6px;">${badgeHtml}</div>` : ""}
+              <a href="/cafe/${p.id}" style="display:inline-block;margin-top:10px;font-size:12px;padding:8px 12px;border-radius:12px;background:${ANEMI.teal};color:white;text-decoration:none;">Bekijk café</a>
+            </div>
+          </div>
+        `;
+
+        popup.setLngLat(coords).setHTML(card).addTo(map);
+      });
+
+      map.on("mouseenter", "unclustered-point", () => (map.getCanvas().style.cursor = "pointer"));
+      map.on("mouseleave", "unclustered-point", () => (map.getCanvas().style.cursor = ""));
+    });
+
+      return () => map.remove();
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [styleUrl, centerNL]);
+
+  // Update source on filter change
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !map.isStyleLoaded()) return;
+    const src = map.getSource("cafes") as any;
+    if (src) src.setData(geo);
+  }, [geo]);
+
+  return (
+    <div>
+      {/* Filter bar */}
+      <div
+        style={{
+          display: "flex",
+          gap: 8,
+          flexWrap: "wrap",
+          marginBottom: 12,
+          alignItems: "center",
+        }}
+      >
+        <span style={{ fontSize: 13, color: ANEMI.muted }}>Filters:</span>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          {cities.map((c) => (
+            <button
+              key={c}
+              onClick={() => setCity(c)}
+              style={{
+                fontSize: 13,
+                padding: "8px 12px",
+                borderRadius: 999,
+                border: `1px solid ${c === city ? ANEMI.teal : "#E6ECF2"}`,
+                background: c === city ? ANEMI.tealSoft : "#fff",
+              }}
+            >
+              {c}
+            </button>
+          ))}
+          <label
+            style={{
+              fontSize: 13,
+              padding: "8px 12px",
+              borderRadius: 999,
+              border: "1px solid #E6ECF2",
+              background: onlyVerified ? ANEMI.tealSoft : "#fff",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 8,
+              cursor: "pointer",
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={onlyVerified}
+              onChange={(e) => setOnlyVerified(e.target.checked)}
+            />
+            Verified
+          </label>
+        </div>
+      </div>
+
+      {/* Map */}
+      <div ref={nodeRef} style={containerStyle} />
+
+      {/* Legend */}
+      <div style={{ display: "flex", gap: 16, marginTop: 10, alignItems: "center" }}>
+        <span style={{ fontSize: 12, color: ANEMI.muted }}>Legenda:</span>
+        <span
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            fontSize: 12,
+            color: ANEMI.muted,
+          }}
+        >
+          <i
+            style={{
+              width: 12,
+              height: 12,
+              borderRadius: 6,
+              background: ANEMI.verified,
+              display: "inline-block",
+              border: "2px solid #fff",
+              boxShadow: "0 1px 2px rgba(0,0,0,.2)",
+            }}
+          />
+          Verified café
+        </span>
+        <span
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            fontSize: 12,
+            color: ANEMI.muted,
+          }}
+        >
+          <i
+            style={{
+              width: 12,
+              height: 12,
+              borderRadius: 6,
+              background: ANEMI.teal,
+              display: "inline-block",
+              border: "2px solid #fff",
+              boxShadow: "0 1px 2px rgba(0,0,0,.2)",
+            }}
+          />
+          Alle cafés
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/use-form-validation.ts
+++ b/src/lib/use-form-validation.ts
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 
 export function useFormValidation<T extends Record<string, any>>(
   initialValues: T,
-  validationRules: Record<keyof T, ((value: any) => string | true)[]>
+  validationRules: Record<keyof T, ((value: any, values: T) => string | true)[]>
 ) {
   const [values, setValues] = useState<T>(initialValues);
   const [errors, setErrors] = useState<Record<keyof T, string>>({} as Record<keyof T, string>);

--- a/src/theme/anemi.ts
+++ b/src/theme/anemi.ts
@@ -1,0 +1,13 @@
+export const ANEMI = {
+  ink: "#0E1726",
+  teal: "#2DA7A0",
+  tealSoft: "#BFE6E3",
+  sand: "#F2EDE6",
+  cream: "#FAF8F5",
+  accent: "#FFB267",      // subtle warmth, not “coffee brown”
+  verified: "#2EC071",    // green check
+  muted: "#8A97A6",
+  shadow: "0 10px 30px rgba(14,23,38,.18)",
+  radius: "16px",
+};
+


### PR DESCRIPTION
## Summary
- add theme token file for Anemi brand
- introduce MapLibre-based map component with clustering, popups, and filters
- document MapTiler key env and add maplibre-gl dependency
- expose the map via a `/map` page and document required environment variables
- allow form validators to inspect other fields for cross-field checks

## Testing
- `npm test` *(fails: Test Suites: 5 failed, 23 passed, 28 total)*
- `npm run build` *(fails: Failed to fetch Google Fonts Inter and Poppins)*

------
https://chatgpt.com/codex/tasks/task_e_68989fe7e474832d83134ffe5e2bac54